### PR TITLE
Fix code generation in android platform

### DIFF
--- a/lyrics-android/src/main/java/com/flipkart/lyrics/android/handlers/AndroidObjectTypeHandler.java
+++ b/lyrics-android/src/main/java/com/flipkart/lyrics/android/handlers/AndroidObjectTypeHandler.java
@@ -1,0 +1,70 @@
+package com.flipkart.lyrics.android.handlers;
+
+import com.flipkart.lyrics.config.Tune;
+import com.flipkart.lyrics.helper.Helper;
+import com.flipkart.lyrics.model.FieldType;
+import com.flipkart.lyrics.model.MetaInfo;
+import com.flipkart.lyrics.model.VariableModel;
+import com.flipkart.lyrics.processor.fields.ObjectTypeHandler;
+
+import java.util.function.Function;
+
+/**
+ * In android, we are not using enums and instead stringdefs are used. So all enum usages should be replaced with
+ * {@link java.lang.String} type. When enums are used as member variables, it will be converted to
+ * {@link java.lang.String} type by {@link AndroidEnumTypeHandler} and {@link AndroidEnumParameterTypeHandler}. When
+ * enums are used as type inside any collections like {@link java.util.Map} or {@link java.util.List} it will be
+ * handled in this object type handler. For this in the json schema mention the fieldType as ENUM.
+ * <p />
+ * Following sample json represents the declaration of {@link java.util.List} member variable with enum as type.
+ *
+ * <pre>
+ * {@code
+ * {
+ *   "type": "CLASS",
+ *   "fields": {
+ *     "listOfShapes": {
+ *       "fieldType": "OBJECT",
+ *       "type": {
+ *         "type": "java.util.List",
+ *         "types": [
+ *            {
+ *                "type": "com.myexample.enum.Shape",
+ *                "fieldType": "ENUM"
+ *            }
+ *         ]
+ *       }
+ *     }
+ *   }
+ * }
+ * }
+ * </pre>
+ * <p />
+ * Generated code will be,
+ * <pre>
+ * {@code
+ * // Android
+ * List<String> listOfShapes;
+ *
+ * // Other platforms
+ * List<Shape> listOfShapes;
+ * }
+ * </pre>
+ */
+public class AndroidObjectTypeHandler extends ObjectTypeHandler {
+
+    public AndroidObjectTypeHandler(Tune tune, MetaInfo metaInfo) {
+        super(tune, metaInfo);
+    }
+
+    @Override
+    protected Function<VariableModel, String> getTypeFromVariableModelFunction() {
+        return inlinedVariableModel -> {
+            if (FieldType.ENUM == inlinedVariableModel.getFieldType()) {
+                return tune.getChords().handleString();
+            } else {
+                return Helper.getTypeFromVariableModel(inlinedVariableModel, tune.getChords());
+            }
+        };
+    }
+}

--- a/lyrics-android/src/main/java/com/flipkart/lyrics/android/sets/AndroidFieldTypeHandlerSet.java
+++ b/lyrics-android/src/main/java/com/flipkart/lyrics/android/sets/AndroidFieldTypeHandlerSet.java
@@ -17,6 +17,7 @@
 package com.flipkart.lyrics.android.sets;
 
 import com.flipkart.lyrics.android.handlers.AndroidEnumTypeHandler;
+import com.flipkart.lyrics.android.handlers.AndroidObjectTypeHandler;
 import com.flipkart.lyrics.processor.fields.FieldTypeHandler;
 import com.flipkart.lyrics.sets.DefaultFieldTypeHandlerSet;
 
@@ -24,6 +25,11 @@ import com.flipkart.lyrics.sets.DefaultFieldTypeHandlerSet;
  * Created by anshul.garg on 13/01/17.
  */
 public class AndroidFieldTypeHandlerSet extends DefaultFieldTypeHandlerSet {
+
+    @Override
+    public FieldTypeHandler getObjectTypeHandler() {
+        return new AndroidObjectTypeHandler(tune, metaInfo);
+    }
 
     @Override
     public FieldTypeHandler getEnumTypeHandler() {

--- a/lyrics-core/src/main/java/com/flipkart/lyrics/model/VariableModel.java
+++ b/lyrics-core/src/main/java/com/flipkart/lyrics/model/VariableModel.java
@@ -17,6 +17,7 @@
 package com.flipkart.lyrics.model;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Created by shrey.garg on 28/11/16.
@@ -24,6 +25,7 @@ import java.util.Arrays;
 public class VariableModel {
     private String type;
     private VariableModel[] types = new VariableModel[0];
+    private FieldType fieldType;
 
     public VariableModel() {
     }
@@ -45,6 +47,14 @@ public class VariableModel {
         return types;
     }
 
+    public FieldType getFieldType() {
+        return fieldType;
+    }
+
+    public void setFieldType(FieldType fieldType) {
+        this.fieldType = fieldType;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -53,12 +63,14 @@ public class VariableModel {
         VariableModel that = (VariableModel) o;
 
         if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        if (!Objects.equals(fieldType, that.fieldType)) return false;
         return Arrays.equals(types, that.types);
     }
 
     @Override
     public int hashCode() {
         int result = type != null ? type.hashCode() : 0;
+        result += fieldType != null ? fieldType.hashCode() : 0;
         result = 31 * result + Arrays.hashCode(types);
         return result;
     }

--- a/lyrics-core/src/main/java/com/flipkart/lyrics/processor/fields/ObjectTypeHandler.java
+++ b/lyrics-core/src/main/java/com/flipkart/lyrics/processor/fields/ObjectTypeHandler.java
@@ -17,10 +17,14 @@
 package com.flipkart.lyrics.processor.fields;
 
 import com.flipkart.lyrics.config.Tune;
+import com.flipkart.lyrics.helper.Helper;
 import com.flipkart.lyrics.model.FieldModel;
 import com.flipkart.lyrics.model.InitializerModel;
 import com.flipkart.lyrics.model.MetaInfo;
+import com.flipkart.lyrics.model.VariableModel;
 import com.flipkart.lyrics.specs.*;
+
+import java.util.function.Function;
 
 import static com.flipkart.lyrics.helper.Helper.*;
 
@@ -39,7 +43,7 @@ public class ObjectTypeHandler extends FieldTypeHandler {
         if (fieldModel.getType() == null || fieldModel.getType().getType() == null) {
             typeName = TypeName.OBJECT;
         } else {
-            typeName = getResolvedTypeName(fieldModel.getType(), metaInfo.getGenericVariables(), tune.getChords());
+            typeName = getResolvedTypeName(getTypeFromVariableModelFunction(), fieldModel.getType(), metaInfo.getGenericVariables());
         }
 
         typeName = fieldModel.isArray() ? ArrayTypeName.of(typeName) : typeName;
@@ -57,5 +61,9 @@ public class ObjectTypeHandler extends FieldTypeHandler {
         }
 
         return builder;
+    }
+
+    protected Function<VariableModel, String> getTypeFromVariableModelFunction() {
+        return Helper.getTypeFromVariableModelFunction(tune.getChords());
     }
 }


### PR DESCRIPTION
Due to performance implications, we dont use enum in the android platform. Instead we use `String` as the type along with annotations to ensure type safety during the compile time. In Lyrics, we do have this special handling to not generate enum and instead use `String`. Refer to the handler classes [here](https://github.com/flipkart-incubator/Lyrics/blob/master/lyrics-android/src/main/java/com/flipkart/lyrics/android/handlers/AndroidEnumTypeHandler.java) and [here](https://github.com/flipkart-incubator/Lyrics/blob/master/lyrics-android/src/main/java/com/flipkart/lyrics/android/handlers/AndroidEnumParameterTypeHandler.java).

Code generation works fine when enums are directly used as member variables inside the classes. But when enums are passed as type to collections, it is not converted to string. For example, considering `Shape` as an enum type,

```
// Other Platforms
Shape shape;

// Android Platform
String shape;

// Other Platforms
List<Shape> listofShapes;

// Android Platform
List<Shape> listofShapes;   << This is incorrect
List<String> listOfShapes;   << This is correct generation
```

When collections are being generated we pass the classes that needs to be parametrized as type. To fix this issue, we can pass `fieldType` optionally, and based on the `fieldType` we can override behavior as needed. Sample json schema looks like this,

```
      {
        "type": "CLASS",
        "fields": {
          "listOfShapes": {
            "fieldType": "OBJECT",
            "type": {
              "type": "java.util.List",
              "types": [
                 {
                   "type": "com.myexample.enum.Shape",
                   "fieldType": "ENUM"
                 }
              ]
            }
          }
        }
      }
```

Since `fieldType` is optional and used only in the overridden `ObjectTypeHandler` it will not affect the code generation for other use cases/platforms.
